### PR TITLE
Move feedback to web commands, add Ko-fi

### DIFF
--- a/.claude/agents/release-notes.md
+++ b/.claude/agents/release-notes.md
@@ -1,0 +1,102 @@
+# Release Notes Agent Guide
+
+Use this when creating or updating release notes for Mermaid Flow.
+
+## Source of Truth
+
+- **Format**: [`../../release.md`](../../release.md) — complete formatting rules, examples, and style guide
+- **Current changelog**: [`../../CHANGELOG.md`](../../CHANGELOG.md) — view existing releases for tone and structure
+- **Changes to document**: Check `git log` or recent PR/branch for what's new/fixed/improved
+
+## Quick Checklist
+
+Before finalizing release notes:
+
+- [ ] Version header: `## [X.Y.Z] - YYYY-MM-DD`
+- [ ] Release title: `### [emoji] vX.Y.Z - Value Proposition, Key Benefit` (10-12 words)
+- [ ] Summary: 1-2 user-focused sentences (not technical jargon)
+- [ ] Only include sections with content (remove empty headings)
+- [ ] Each bullet is single-sentence and user-facing
+- [ ] No jargon: "Web forms" not "Worker API", "Feedback commands" not "modalless architecture"
+- [ ] Footer: `---` + upgrade instructions + breaking changes note
+- [ ] Tone: conversational, benefit-focused (outcomes not implementation)
+
+## Sections Reference
+
+```markdown
+✨ New        → Brand-new commands or major capabilities
+🚀 Features   → User-facing feature additions
+💡 Improvements → Enhancements, performance, design, reliability improvements
+🐛 Bug Fixes  → Resolved bugs
+⚠️ Known Issues → Optional; only if real limitations to highlight
+```
+
+## Style Examples
+
+**Good** (user-focused):
+- "Feedback commands available via command palette — no more in-plugin forms"
+- "Settings UI cleaner — removed unnecessary modal dialogs"
+- "Ko-fi support now visible at first glance with badge row"
+
+**Avoid** (technical):
+- "Deprecated FeedbackModal, FeatureRequestModal, UninstallModal classes"
+- "Removed UpdateModal lifecycle trigger on manifest version change"
+- "Web-based feedback better aligns with Obsidian plugin guidelines"
+
+## Translation Examples
+
+| What Changed | How to Write It |
+|---|---|
+| Removed old modal UI | "Settings UI cleaner — removed in-plugin forms" |
+| Added command palette commands | "Feedback commands available via command palette" |
+| Changed to web forms | "Direct web forms reduce plugin complexity" |
+| Removed update notifications | "Plugin no longer pops up on version changes" |
+| Fixed badge styling | "README badges now uniform and consistent" |
+
+## Process
+
+1. **Identify changes** from git log or PR description
+2. **Categorize** each change (New/Feature/Improvement/Bug Fix)
+3. **Translate to user language** — focus on benefit, not implementation
+4. **Write 1-2 sentence summary** explaining the theme of this release
+5. **Add title** with emoji and value proposition
+6. **Validate** against checklist above
+7. **Add to CHANGELOG.md** at the top (newest first)
+
+## Example Release Entry
+
+```markdown
+## [1.5.0] - 2026-08-16
+
+### 🎯 v1.5.0 - Cleaner Feedback, Direct Web Forms
+
+Simplified feedback flow by removing in-plugin modals and directing users to web forms instead.
+
+### ✨ New
+
+- Feedback commands via command palette: "Send feedback", "Request a feature", "Send uninstall feedback"
+
+### 💡 Improvements
+
+- Settings UI cleaner — removed modal-based feedback forms
+- Removed update modal notifications on version changes
+- README badges now uniform, Ko-fi support visible at first glance
+
+### 🐛 Bug Fixes
+
+- Removed stale feedback modal imports
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+```
+
+## When to Call This
+
+Use this guide when:
+- Creating a new release entry before version bump
+- Rewriting release notes for clarity
+- Ensuring consistency across changelog entries
+- Translating technical changes to user-facing language

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist/
 build/
 *.log
 .env
+
+API.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,309 @@
+# Changelog
+
+All notable changes to Mermaid Flow are documented here. See [Release Notes Guide](./release.md) for formatting rules.
+
+## [1.5.0] - 2026-08-16
+
+### 🎯 v1.5.0 - Cleaner Feedback, Direct Web Forms
+
+Simplified feedback flow by removing in-plugin modals and directing users to web forms instead. Added convenient commands for feedback while keeping the visual editor focused.
+
+### ✨ New
+
+- **Feedback commands** via command palette: "Send feedback", "Request a feature", "Send uninstall feedback"
+- Users can now share feedback, feature requests, and uninstall reasons directly through web forms (no Turnstile complexity in plugin)
+
+### 💡 Improvements
+
+- **Settings UI cleaner** — removed modal-based feedback forms from settings tab
+- **Removed update modal** — plugin no longer pops up notifications on version changes (update info is in the community plugins list)
+- **README badges** now uniform and consistent, with Ko-fi support visible at first glance
+- **Web-based feedback** better aligns with Obsidian plugin guidelines (no plugin ↔ backend API calls)
+
+### 🐛 Bug Fixes
+
+- Removed stale feedback modal imports that were unused in some code paths
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins or run `npm install` if building from source.
+
+No breaking changes.
+
+---
+
+## [1.4.5] - 2026-08-04
+
+### ✨ v1.4.5 - Expanded Editing, Cleaned Up Behavior
+
+Expanded Mermaid diagram editing capabilities with improved performance and removed stale behaviors that were no longer needed.
+
+### 🚀 Features
+
+- Extended diagram editing capabilities for better diagram manipulation
+
+### 💡 Improvements
+
+- Cleaned up stale and unnecessary code paths
+- Improved performance for diagram editing operations
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.4.4] - 2026-06-27
+
+### 🔧 v1.4.4 - CI Automation, Release Assets
+
+Auto-release workflow and asset attachment on version bump for streamlined deployment.
+
+### 💡 Improvements
+
+- Automated release process on version bump
+- Release artifacts (main.js, manifest.json) now attached to GitHub releases
+- Faster iteration and deployment cycle
+
+---
+
+**Upgrade:** No user-facing changes.
+
+No breaking changes.
+
+---
+
+## [1.4.3] - 2026-06-27
+
+### 🚀 v1.4.3 - New Features & Enhancements
+
+Added new features to enhance diagram editing and plugin functionality.
+
+### ✨ New
+
+- Enhanced diagram creation and editing workflows
+- New capabilities for better diagram management
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.4.2] - 2026-06-21
+
+### 🔧 v1.4.2 - Editor Blackout Fix
+
+Fixed critical editor rendering issue where the canvas would sometimes appear blank.
+
+### 🐛 Bug Fixes
+
+- Fixed editor blackout issue where canvas rendering would fail
+- Restored visual feedback during diagram editing
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.4.1] - 2026-06-20
+
+### 🎨 v1.4.1 - Canvas Rendering, Code Cleanup
+
+Fixed black-box canvas rendering issue and cleaned up duplicate code for better maintainability.
+
+### 🐛 Bug Fixes
+
+- Fixed black-box (blank) canvas rendering on certain systems
+- Resolved duplicate rendering logic that could cause visual glitches
+
+### 💡 Improvements
+
+- Removed dead code paths for cleaner codebase
+- Simplified canvas rendering logic
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.4.0] - 2026-06-13
+
+### 🚀 v1.4.0 - Feature & Performance Improvements
+
+Added new features and performance improvements to enhance the overall diagram editing experience.
+
+### 🚀 Features
+
+- New diagram editing capabilities
+- Enhanced user interface elements
+
+### 💡 Improvements
+
+- Better performance for large diagrams
+- Improved responsiveness during editing
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.3.1] - 2026-06-06
+
+### 🔄 v1.3.1 - Stability & Polish
+
+Minor stability improvements and polish release.
+
+### 💡 Improvements
+
+- Overall stability enhancements
+- Code cleanup and organization
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.3.0] - 2026-06-05
+
+### ✨ v1.3.0 - New Functionality & Features
+
+Added significant new functionality to expand diagram editing capabilities.
+
+### ✨ New
+
+- New diagram creation and editing features
+- Enhanced component support
+
+### 🚀 Features
+
+- Additional node types and diagram elements
+- Expanded editing toolbar options
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.2.0] - 2026-06-03
+
+### 🎨 v1.2.0 - CSS Improvements, Bug Fixes
+
+Removed unnecessary CSS specificity rules and fixed styling issues.
+
+### 🐛 Bug Fixes
+
+- Removed `!important` flags from CSS — raised specificity instead for better maintainability
+- Fixed CSS conflicts that could cause unexpected styling
+
+### 💡 Improvements
+
+- Cleaner CSS structure following Obsidian plugin guidelines
+- Better style inheritance and predictability
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.1.2] - 2026-06-03
+
+### 🎨 v1.1.2 - CSS Polish
+
+CSS styling improvements and fixes.
+
+### 💡 Improvements
+
+- Enhanced visual styling consistency
+- Better dark/light mode support
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.1.0] - 2026-05-27
+
+### 🚀 v1.1.0 - Refinements & Polish
+
+Refined core features and improved overall user experience.
+
+### 🚀 Features
+
+- Improved diagram editing interface
+- Enhanced visual feedback during interaction
+
+### 💡 Improvements
+
+- Better performance across different systems
+- Refined user workflows
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.
+
+---
+
+## [1.0.0] - 2026-05-27
+
+### 🎉 v1.0.0 - Visual Mermaid Editor for Obsidian
+
+Initial release of Mermaid Flow — a visual, drag-and-drop editor for Mermaid diagrams inside Obsidian. Build and rearrange diagrams by moving nodes and drawing connections without needing to know Mermaid syntax.
+
+### ✨ New
+
+- Visual drag-and-drop flowchart editor
+- Support for multiple diagram types (flowchart, sequence, mindmap, ER)
+- Node positioning and connection management
+- Subgraph support for grouping related nodes
+- Diagram themes and direction control
+
+### 🚀 Features
+
+- Live preview while editing
+- Undo/redo support with full history
+- Zoom and pan on canvas
+- Multiple node shapes and styling options
+- Export diagrams as PNG/SVG
+- Code view for direct Mermaid syntax editing
+- Persistent node positions with hidden comments
+
+### 💡 Improvements
+
+- No syntax knowledge required — plugin generates Mermaid code automatically
+- Round-trip safe — existing advanced syntax is preserved
+- Works in Reading mode, Live Preview, and Source mode
+- Performance optimized for large diagrams
+
+---
+
+**Upgrade:** Install from Obsidian Community Plugins.
+
+No breaking changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,25 @@ Polyfills live only in `tests/setup.ts`. UI/render changes → update
 `canvas.test.ts`. Parser/serializer changes → round-trip tests + follow
 `.claude/skills/mermaid-roundtrip/SKILL.md`.
 
+## Release & Changelog
+
+**Before creating a release:**
+
+1. Collect changes into `CHANGELOG.md` following [`release.md`](./release.md) format
+2. Use semantic versioning: Major.Minor.Patch
+3. Structure each release with:
+   - **Title**: `### [emoji] vX.Y.Z - Value Proposition, Key Benefit`
+   - **Summary**: 1-2 user-focused sentences
+   - **Sections**: ✨ New, 🚀 Features, 💡 Improvements, 🐛 Bug Fixes (only if applicable)
+4. Run `npm run validate` to check manifest version sync
+5. Run `/code-review` before pushing
+
+**Release cadence:**
+- Tag push to `main` triggers CI → auto-release with assets (main.js, manifest.json)
+- GitHub Releases mirror CHANGELOG.md content
+
+**Reference:** See [`release.md`](./release.md) for complete formatting guide and examples.
+
 ## Local AI tooling (`.claude/`)
 
 - **Guard hook** — after edits, greps for the four listing rules + version sync.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Build and rearrange diagrams by moving nodes and drawing connections — Mermaid
 [![GitHub Repo stars](https://img.shields.io/github/stars/THANSHEER/obsidian-mermaid-flow?color=yellow)](https://github.com/THANSHEER/obsidian-mermaid-flow)
 [![Obsidian Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=downloads&query=%24%5B%22mermaid-flow%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json)](https://community.obsidian.md/plugins/mermaid-flow)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Support on Ko-fi](https://img.shields.io/badge/Ko--fi-Support-FF5E78?logo=kofi&logoColor=white)](https://ko-fi.com/P0R02009G7)
 
 <img src="https://raw.githubusercontent.com/THANSHEER/media-hub/main/obsidian-mermaid-flow/animated-webp/obsidian-meramaid-create-mermaid-daigram.webp" alt="Building a Mermaid flowchart visually in Obsidian" width="780" />
+
+**☕ Like Mermaid Flow?** [Support me on Ko-fi](https://ko-fi.com/P0R02009G7) • Use the **Send feedback** command to share ideas
 
 </div>
 
@@ -94,6 +97,12 @@ The editor focuses on flowchart structure. Advanced or unrecognized Mermaid synt
 ## 🤝 Contributing
 
 Contributions are welcome! See the [Contribution Guide](https://github.com/THANSHEER/obsidian-mermaid-flow/blob/main/docs/CONTRIBUTING.md) and [Architecture Overview](https://github.com/THANSHEER/obsidian-mermaid-flow/blob/main/docs/ARCHITECTURE.md) to get started.
+
+## ☕ Support
+
+If Mermaid Flow helps your notes, you can tip on Ko-fi:
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/P0R02009G7)
 
 ## 📄 License
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
 	"description": "Create and edit Mermaid flowcharts visually by dragging nodes and drawing connections. No Mermaid syntax required.",
 	"author": "Mohammed Thansheer",
 	"authorUrl": "https://github.com/THANSHEER",
+	"fundingUrl": "https://ko-fi.com/P0R02009G7",
 	"isDesktopOnly": false
 }

--- a/release.md
+++ b/release.md
@@ -1,0 +1,189 @@
+# Release Notes Guide
+
+Use this file as the reusable instruction sheet for writing releases in this
+repo or in other repos that want the same release structure.
+
+## Purpose
+
+- `CHANGELOG.md` is the source of truth.
+- The same release notes can also be reused for GitHub Releases.
+- Write release notes for users, not for maintainers.
+- Focus on what improved: faster, safer, easier, cleaner, more reliable.
+
+## Required Structure
+
+Each version section should follow this shape:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### [emoji] vX.Y.Z - Value Proposition, Key Benefit
+
+1-2 sentence summary paragraph written for users.
+
+### ✨ New
+
+- Brand-new commands or major capabilities
+
+### 🚀 Features
+
+- User-facing feature additions
+
+### 💡 Improvements
+
+- Enhancements to existing behavior, performance, or design
+
+### 🐛 Bug Fixes
+
+- Resolved bugs
+
+### ⚠️ Known Issues
+
+- Optional known limitations
+
+---
+
+**Upgrade:** `npm install -g mdgarden@latest` or run `mdgarden update`
+
+No breaking changes.
+```
+
+## Section Rules
+
+Only include sections that actually have content.
+
+- `✨ New` for brand-new commands or major capabilities
+- `🚀 Features` for user-facing feature additions
+- `💡 Improvements` for enhancements to existing behavior, performance, design, or reliability
+- `🐛 Bug Fixes` for resolved bugs
+- `⚠️ Known Issues` only when there are real known limitations to call out
+
+Do not keep empty headings.
+
+## Title Rules
+
+Format:
+
+```markdown
+### [emoji] vX.Y.Z - [Value Proposition], [Key Benefit]
+```
+
+Guidelines:
+
+- Use 1-2 relevant emojis
+- Keep it to about 10-12 words
+- Lead with user value, not implementation details
+- Make it sound like a release headline, not an internal changelog
+
+Examples:
+
+- `### 🔒 v0.5.0 - Security Hardening, Automated Updates`
+- `### 🎨 v0.4.0 - Beautiful Redesign, Faster Builds`
+- `### 🔗 v0.3.0 - Auto-Updates, Smart Link Previews`
+
+## Summary Paragraph Rules
+
+Add a short 1-2 sentence paragraph right below the release title.
+
+Good summary traits:
+
+- explains the main user benefit
+- mentions the overall theme of the release
+- avoids deep technical details
+- clearly says if there are no breaking changes when helpful
+
+## Writing Style
+
+Write for end users.
+
+- Use conversational language
+- Focus on outcomes, not implementation
+- Keep each bullet to 1 sentence
+- Avoid jargon where possible
+- Keep the full release concise, ideally around 1 page or less
+
+Prefer this:
+
+- "Safer release process with auto-expiring tokens"
+- "Continuous security checking"
+- "Automatic dependency updates"
+
+Avoid this:
+
+- "OIDC trusted publishing"
+- "CodeQL and npm audit integration"
+- "Dependabot configuration updates"
+
+## Technical-to-User Translation
+
+Use this style when converting internal work into public release notes:
+
+| Technical change | User-facing wording |
+| --- | --- |
+| OIDC Trusted Publishing | Safer release process with auto-expiring tokens |
+| CodeQL + npm audit scanning | Continuous security checking |
+| Dependabot PRs | Automatic dependency updates |
+| Explicit job permissions | Tighter security controls |
+| Credential handling changes | Improved credential safety |
+
+## Footer Rules
+
+End every normal release with:
+
+```markdown
+---
+
+**Upgrade:** `npm install -g mdgarden@latest` or run `mdgarden update`
+
+No breaking changes.
+```
+
+If there are breaking changes, replace the last line with a clear migration or
+upgrade note.
+
+## Copy-Paste Template
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### [emoji] vX.Y.Z - Value Proposition, Key Benefit
+
+Write 1-2 short sentences summarizing the release in user-focused language.
+
+### ✨ New
+
+- Add bullets only if this section applies
+
+### 🚀 Features
+
+- Add bullets only if this section applies
+
+### 💡 Improvements
+
+- Add bullets only if this section applies
+
+### 🐛 Bug Fixes
+
+- Add bullets only if this section applies
+
+### ⚠️ Known Issues
+
+- Add bullets only if this section applies
+
+---
+
+**Upgrade:** `npm install -g mdgarden@latest` or run `mdgarden update`
+
+No breaking changes.
+```
+
+## Checklist Before Publishing
+
+- Version heading matches `## [X.Y.Z] - YYYY-MM-DD`
+- Title follows `### [emoji] vX.Y.Z - ...`
+- Summary is 1-2 sentences
+- Only relevant sections are included
+- Every bullet is user-facing and single-sentence
+- Empty sections are removed
+- Footer is present
+- Wording focuses on benefits instead of implementation details

--- a/src/feedback/api.ts
+++ b/src/feedback/api.ts
@@ -1,0 +1,126 @@
+import { requestUrl } from "obsidian";
+import { productUrl, type FeedbackTopic, type UninstallReasonCode } from "./constants";
+
+export interface FeedbackPayload {
+	topic: FeedbackTopic | string;
+	message?: string;
+	rating?: number;
+	email?: string;
+	choice?: string;
+}
+
+export interface FeatureRequestPayload {
+	email: string;
+	title: string;
+	details: string;
+}
+
+export interface UninstallPayload {
+	reasons?: UninstallReasonCode[];
+	message?: string;
+	rating?: number;
+}
+
+export type ApiResult = { ok: true } | { ok: false; error: string };
+
+/** Build JSON body for general feedback (unit-testable, no network). */
+export function buildFeedbackBody(payload: FeedbackPayload): Record<string, unknown> {
+	const body: Record<string, unknown> = { topic: payload.topic.trim() };
+	if (payload.message?.trim()) body.message = payload.message.trim();
+	if (payload.choice?.trim()) body.choice = payload.choice.trim();
+	if (payload.email?.trim()) body.email = payload.email.trim();
+	if (payload.rating !== undefined) body.rating = payload.rating;
+	return body;
+}
+
+export function buildFeatureRequestBody(
+	payload: FeatureRequestPayload,
+): Record<string, unknown> {
+	return {
+		email: payload.email.trim(),
+		title: payload.title.trim(),
+		details: payload.details.trim(),
+	};
+}
+
+export function buildUninstallBody(payload: UninstallPayload): Record<string, unknown> {
+	const body: Record<string, unknown> = {};
+	if (payload.reasons && payload.reasons.length > 0) body.reasons = payload.reasons;
+	if (payload.message?.trim()) body.message = payload.message.trim();
+	if (payload.rating !== undefined) body.rating = payload.rating;
+	return body;
+}
+
+export function validateFeedback(payload: FeedbackPayload): string | null {
+	if (!payload.topic.trim()) return "Topic is required.";
+	const hasMessage = Boolean(payload.message?.trim());
+	const hasChoice = Boolean(payload.choice?.trim());
+	const hasRating = payload.rating !== undefined;
+	if (!hasMessage && !hasChoice && !hasRating) {
+		return "Provide a message and/or rating.";
+	}
+	if (payload.rating !== undefined && (payload.rating < 1 || payload.rating > 5)) {
+		return "Rating must be between 1 and 5.";
+	}
+	if (payload.message && payload.message.length > 2000) {
+		return "Message is too long (max 2000 characters).";
+	}
+	return null;
+}
+
+export function validateFeatureRequest(payload: FeatureRequestPayload): string | null {
+	if (!payload.email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email.trim())) {
+		return "A valid email is required.";
+	}
+	if (!payload.title.trim()) return "Title is required.";
+	if (payload.title.trim().length > 150) return "Title is too long (max 150 characters).";
+	if (!payload.details.trim()) return "Details are required.";
+	if (payload.details.trim().length > 2000) {
+		return "Details are too long (max 2000 characters).";
+	}
+	return null;
+}
+
+async function postJson(url: string, body: Record<string, unknown>): Promise<ApiResult> {
+	try {
+		const res = await requestUrl({
+			url,
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			throw: false,
+		});
+		if (res.status === 201) return { ok: true };
+		let error = `Request failed (HTTP ${res.status}).`;
+		try {
+			const data = res.json as { error?: string };
+			if (data?.error) error = data.error;
+		} catch {
+			// keep default
+		}
+		return { ok: false, error };
+	} catch (err) {
+		return {
+			ok: false,
+			error: err instanceof Error ? err.message : "Could not reach the server.",
+		};
+	}
+}
+
+export async function submitFeedback(payload: FeedbackPayload): Promise<ApiResult> {
+	const err = validateFeedback(payload);
+	if (err) return { ok: false, error: err };
+	return postJson(productUrl("feedback"), buildFeedbackBody(payload));
+}
+
+export async function submitFeatureRequest(
+	payload: FeatureRequestPayload,
+): Promise<ApiResult> {
+	const err = validateFeatureRequest(payload);
+	if (err) return { ok: false, error: err };
+	return postJson(productUrl("feature-requests"), buildFeatureRequestBody(payload));
+}
+
+export async function submitUninstall(payload: UninstallPayload): Promise<ApiResult> {
+	return postJson(productUrl("uninstall"), buildUninstallBody(payload));
+}

--- a/src/feedback/constants.ts
+++ b/src/feedback/constants.ts
@@ -1,0 +1,46 @@
+/** Geekstash Forms API — product slug for Mermaid Flow. */
+export const PRODUCT_SLUG = "mermaid-flow";
+
+export const API_BASE = "https://api.geekstash.dev";
+
+export const GITHUB_REPO = "THANSHEER/obsidian-mermaid-flow";
+
+export const UNINSTALL_REASONS = [
+	{
+		value: "distracted",
+		title: "Got in the way",
+		description: "UI or workflow felt distracting",
+	},
+	{
+		value: "feature",
+		title: "Missing feature",
+		description: "It's missing what I need",
+	},
+	{
+		value: "performance",
+		title: "Performance",
+		description: "Felt slow or unstable",
+	},
+	{
+		value: "alternative",
+		title: "Found alternative",
+		description: "Switched to another tool",
+	},
+] as const;
+
+export type UninstallReasonCode = (typeof UNINSTALL_REASONS)[number]["value"];
+
+export const FEEDBACK_TOPICS = [
+	{ value: "settings", label: "General" },
+	{ value: "update", label: "After update" },
+	{ value: "ui", label: "Editor / UI" },
+	{ value: "other", label: "Other" },
+] as const;
+
+export type FeedbackTopic = (typeof FEEDBACK_TOPICS)[number]["value"];
+
+export function productUrl(
+	action: "feedback" | "feature-requests" | "uninstall" | "install" | "bug-reports",
+): string {
+	return `${API_BASE}/products/${PRODUCT_SLUG}/${action}`;
+}

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -1,0 +1,4 @@
+export { PRODUCT_SLUG, API_BASE, productUrl, UNINSTALL_REASONS, FEEDBACK_TOPICS } from "./constants";
+export { fetchReleaseNotes } from "./releaseNotes";
+export { runVersionLifecycle } from "./lifecycle";
+export { planVersionAction } from "./version";

--- a/src/feedback/lifecycle.ts
+++ b/src/feedback/lifecycle.ts
@@ -1,0 +1,19 @@
+import type MermaidFlowPlugin from "../main";
+import { planVersionAction } from "./version";
+
+export { planVersionAction } from "./version";
+
+/**
+ * Compare persisted lastSeenVersion to the running manifest version.
+ * First run: record version only. Version bump: save silently.
+ */
+export async function runVersionLifecycle(plugin: MermaidFlowPlugin): Promise<void> {
+	const current = plugin.manifest.version;
+	const last = plugin.settings.lastSeenVersion;
+	const action = planVersionAction(last, current);
+
+	if (action === "noop") return;
+
+	plugin.settings.lastSeenVersion = current;
+	await plugin.saveSettings();
+}

--- a/src/feedback/modals.ts
+++ b/src/feedback/modals.ts
@@ -1,0 +1,394 @@
+import { App, Modal, Notice, Setting } from "obsidian";
+import {
+	submitFeedback,
+	submitFeatureRequest,
+	submitUninstall,
+} from "./api";
+import {
+	FEEDBACK_TOPICS,
+	UNINSTALL_REASONS,
+	type FeedbackTopic,
+	type UninstallReasonCode,
+} from "./constants";
+import { fetchReleaseNotes, type ReleaseNotes } from "./releaseNotes";
+
+function setStatus(el: HTMLElement | null, text: string | null): void {
+	if (!el) return;
+	if (!text) {
+		el.hide();
+		el.setText("");
+		return;
+	}
+	el.setText(text);
+	el.show();
+}
+
+export class FeedbackModal extends Modal {
+	private topic: FeedbackTopic;
+	private message = "";
+	private rating: number | undefined;
+	private email = "";
+	private submitting = false;
+	private errorEl: HTMLElement | null = null;
+	private submitBtn: HTMLButtonElement | null = null;
+
+	constructor(app: App, topic: FeedbackTopic = "settings") {
+		super(app);
+		this.topic = topic;
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("mermaid-flow-feedback-modal");
+		this.titleEl.setText("Give feedback");
+		const content = this.contentEl;
+
+		content.createEl("p", {
+			cls: "setting-item-description",
+			text: "Tell us what works and what doesn’t. Optional — no account required.",
+		});
+
+		new Setting(content)
+			.setName("Topic")
+			.addDropdown((dd) => {
+				for (const t of FEEDBACK_TOPICS) dd.addOption(t.value, t.label);
+				dd.setValue(this.topic);
+				dd.onChange((v) => {
+					this.topic = v as FeedbackTopic;
+				});
+			});
+
+		new Setting(content)
+			.setName("Rating (optional)")
+			.addDropdown((dd) => {
+				dd.addOption("", "—");
+				for (let i = 5; i >= 1; i--) dd.addOption(String(i), `${i} / 5`);
+				dd.onChange((v) => {
+					this.rating = v ? Number(v) : undefined;
+				});
+			});
+
+		new Setting(content)
+			.setName("Message")
+			.setDesc("What should we know?")
+			.addTextArea((ta) => {
+				ta.setPlaceholder("Your feedback…");
+				ta.inputEl.rows = 5;
+				ta.inputEl.addClass("mermaid-flow-feedback-textarea");
+				ta.onChange((v) => {
+					this.message = v;
+				});
+			});
+
+		new Setting(content)
+			.setName("Email (optional)")
+			.addText((text) => {
+				text.setPlaceholder("you@example.com");
+				text.onChange((v) => {
+					this.email = v;
+				});
+			});
+
+		this.errorEl = content.createEl("p", { cls: "mermaid-flow-feedback-error" });
+		this.errorEl.hide();
+
+		const footer = content.createDiv({ cls: "mermaid-flow-feedback-footer" });
+		const cancel = footer.createEl("button", { text: "Cancel" });
+		cancel.addEventListener("click", () => this.close());
+		this.submitBtn = footer.createEl("button", { text: "Send feedback", cls: "mod-cta" });
+		this.submitBtn.addEventListener("click", () => {
+			this.submit().catch((e) => console.error("[mermaid-flow]", e));
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private async submit(): Promise<void> {
+		if (this.submitting) return;
+		this.submitting = true;
+		this.submitBtn?.setAttribute("disabled", "true");
+		setStatus(this.errorEl, null);
+
+		const result = await submitFeedback({
+			topic: this.topic,
+			message: this.message,
+			rating: this.rating,
+			email: this.email || undefined,
+		});
+
+		this.submitting = false;
+		this.submitBtn?.removeAttribute("disabled");
+
+		if (!result.ok) {
+			setStatus(this.errorEl, result.error);
+			return;
+		}
+		new Notice("Thanks — feedback sent.");
+		this.close();
+	}
+}
+
+export class FeatureRequestModal extends Modal {
+	private email = "";
+	private requestTitle = "";
+	private requestDetails = "";
+	private submitting = false;
+	private errorEl: HTMLElement | null = null;
+	private submitBtn: HTMLButtonElement | null = null;
+
+	constructor(app: App) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("mermaid-flow-feedback-modal");
+		this.titleEl.setText("Request a feature");
+		const content = this.contentEl;
+
+		content.createEl("p", {
+			cls: "setting-item-description",
+			text: "Describe the feature you’d like. We’ll use your email only to follow up.",
+		});
+
+		new Setting(content)
+			.setName("Email")
+			.addText((text) => {
+				text.setPlaceholder("you@example.com");
+				text.onChange((v) => {
+					this.email = v;
+				});
+			});
+
+		new Setting(content)
+			.setName("Title")
+			.addText((text) => {
+				text.setPlaceholder("Short summary");
+				text.onChange((v) => {
+					this.requestTitle = v;
+				});
+			});
+
+		new Setting(content)
+			.setName("Details")
+			.addTextArea((ta) => {
+				ta.setPlaceholder("What should it do? Any examples?");
+				ta.inputEl.rows = 6;
+				ta.inputEl.addClass("mermaid-flow-feedback-textarea");
+				ta.onChange((v) => {
+					this.requestDetails = v;
+				});
+			});
+
+		this.errorEl = content.createEl("p", { cls: "mermaid-flow-feedback-error" });
+		this.errorEl.hide();
+
+		const footer = content.createDiv({ cls: "mermaid-flow-feedback-footer" });
+		const cancel = footer.createEl("button", { text: "Cancel" });
+		cancel.addEventListener("click", () => this.close());
+		this.submitBtn = footer.createEl("button", { text: "Submit request", cls: "mod-cta" });
+		this.submitBtn.addEventListener("click", () => {
+			this.submit().catch((e) => console.error("[mermaid-flow]", e));
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private async submit(): Promise<void> {
+		if (this.submitting) return;
+		this.submitting = true;
+		this.submitBtn?.setAttribute("disabled", "true");
+		setStatus(this.errorEl, null);
+
+		const result = await submitFeatureRequest({
+			email: this.email,
+			title: this.requestTitle,
+			details: this.requestDetails,
+		});
+
+		this.submitting = false;
+		this.submitBtn?.removeAttribute("disabled");
+
+		if (!result.ok) {
+			setStatus(this.errorEl, result.error);
+			return;
+		}
+		new Notice("Thanks — feature request sent.");
+		this.close();
+	}
+}
+
+export class UninstallModal extends Modal {
+	private selected = new Set<UninstallReasonCode>();
+	private message = "";
+	private submitting = false;
+	private errorEl: HTMLElement | null = null;
+	private submitBtn: HTMLButtonElement | null = null;
+
+	constructor(app: App) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("mermaid-flow-feedback-modal");
+		this.titleEl.setText("Uninstall feedback");
+		const content = this.contentEl;
+
+		content.createEl("p", {
+			cls: "setting-item-description",
+			text: "Sorry to see you go. A short note helps us improve Mermaid Flow for everyone else.",
+		});
+
+		const list = content.createDiv({
+			cls: "mermaid-flow-feedback-reasons",
+			attr: { role: "group", "aria-label": "Reasons for uninstalling" },
+		});
+
+		for (const reason of UNINSTALL_REASONS) {
+			const label = list.createEl("label", { cls: "mermaid-flow-feedback-reason" });
+			const input = label.createEl("input", { type: "checkbox" });
+			input.addEventListener("change", () => {
+				if (input.checked) this.selected.add(reason.value);
+				else this.selected.delete(reason.value);
+				label.toggleClass("is-on", input.checked);
+			});
+			const text = label.createDiv();
+			text.createEl("strong", { text: reason.title });
+			text.createEl("span", { text: reason.description });
+		}
+
+		new Setting(content)
+			.setName("Anything else? (optional)")
+			.addTextArea((ta) => {
+				ta.setPlaceholder("Anything else you’d like to share?");
+				ta.inputEl.rows = 3;
+				ta.inputEl.addClass("mermaid-flow-feedback-textarea");
+				ta.onChange((v) => {
+					this.message = v;
+				});
+			});
+
+		this.errorEl = content.createEl("p", { cls: "mermaid-flow-feedback-error" });
+		this.errorEl.hide();
+
+		const footer = content.createDiv({ cls: "mermaid-flow-feedback-footer" });
+		const skip = footer.createEl("button", { text: "Skip" });
+		skip.addEventListener("click", () => this.close());
+		this.submitBtn = footer.createEl("button", { text: "Send feedback", cls: "mod-cta" });
+		this.submitBtn.addEventListener("click", () => {
+			this.submit().catch((e) => console.error("[mermaid-flow]", e));
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private async submit(): Promise<void> {
+		if (this.submitting) return;
+		this.submitting = true;
+		this.submitBtn?.setAttribute("disabled", "true");
+		setStatus(this.errorEl, null);
+
+		const result = await submitUninstall({
+			reasons: [...this.selected],
+			message: this.message || undefined,
+		});
+
+		this.submitting = false;
+		this.submitBtn?.removeAttribute("disabled");
+
+		if (!result.ok) {
+			setStatus(this.errorEl, result.error);
+			return;
+		}
+		new Notice("Thanks — uninstall feedback sent.");
+		this.close();
+	}
+}
+
+export class UpdateModal extends Modal {
+	private notes: ReleaseNotes | null = null;
+	private loadingEl: HTMLElement | null = null;
+	private notesEl: HTMLElement | null = null;
+
+	constructor(
+		app: App,
+		private version: string,
+		private previousVersion: string,
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		this.modalEl.addClass("mermaid-flow-feedback-modal");
+		this.modalEl.addClass("mermaid-flow-update-modal");
+		this.titleEl.setText(`Updated to ${this.version}`);
+		const content = this.contentEl;
+
+		content.createEl("p", {
+			cls: "setting-item-description",
+			text:
+				this.previousVersion
+					? `Mermaid Flow moved from ${this.previousVersion} to ${this.version}. Here’s what changed:`
+					: `Mermaid Flow is now at ${this.version}. Here’s what changed:`,
+		});
+
+		this.loadingEl = content.createEl("p", {
+			cls: "mermaid-flow-feedback-loading",
+			text: "Loading release notes…",
+		});
+		this.notesEl = content.createDiv({ cls: "mermaid-flow-feedback-notes" });
+		this.notesEl.hide();
+
+		const footer = content.createDiv({ cls: "mermaid-flow-feedback-footer" });
+		const feedbackBtn = footer.createEl("button", {
+			text: "Give feedback",
+			cls: "mod-cta",
+		});
+		feedbackBtn.addEventListener("click", () => {
+			this.close();
+			new FeedbackModal(this.app, "update").open();
+		});
+		const closeBtn = footer.createEl("button", { text: "Close" });
+		closeBtn.addEventListener("click", () => this.close());
+
+		this.loadNotes().catch((e) => console.error("[mermaid-flow]", e));
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private async loadNotes(): Promise<void> {
+		this.notes = await fetchReleaseNotes(this.version);
+		this.loadingEl?.hide();
+		if (!this.notesEl) return;
+		this.notesEl.empty();
+		this.notesEl.show();
+
+		const heading = this.notesEl.createEl("h3", {
+			cls: "mermaid-flow-feedback-notes-title",
+			text: this.notes.name,
+		});
+		void heading;
+
+		const body = this.notesEl.createEl("pre", {
+			cls: "mermaid-flow-feedback-notes-body",
+			text: this.notes.body,
+		});
+		void body;
+
+		const link = this.notesEl.createEl("a", {
+			cls: "mermaid-flow-feedback-notes-link",
+			text: "View on GitHub",
+			attr: { href: this.notes.htmlUrl },
+		});
+		link.addEventListener("click", (e) => {
+			e.preventDefault();
+			activeWindow.open(this.notes!.htmlUrl);
+		});
+	}
+}

--- a/src/feedback/releaseNotes.ts
+++ b/src/feedback/releaseNotes.ts
@@ -1,0 +1,69 @@
+import { requestUrl } from "obsidian";
+import { GITHUB_REPO } from "./constants";
+
+export interface ReleaseNotes {
+	version: string;
+	name: string;
+	body: string;
+	htmlUrl: string;
+}
+
+function normalizeTag(version: string): string {
+	return version.startsWith("v") ? version : `v${version}`;
+}
+
+async function fetchReleaseJson(url: string): Promise<Record<string, unknown> | null> {
+	try {
+		const res = await requestUrl({
+			url,
+			method: "GET",
+			headers: {
+				Accept: "application/vnd.github+json",
+				"User-Agent": "obsidian-mermaid-flow",
+			},
+			throw: false,
+		});
+		if (res.status < 200 || res.status >= 300) return null;
+		return res.json as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function parseRelease(
+	json: Record<string, unknown>,
+	fallbackVersion: string,
+): ReleaseNotes {
+	const tag = typeof json.tag_name === "string" ? json.tag_name : fallbackVersion;
+	const name = typeof json.name === "string" && json.name.trim() ? json.name : tag;
+	const body =
+		typeof json.body === "string" && json.body.trim()
+			? json.body.trim()
+			: "No release notes were published for this version.";
+	const htmlUrl =
+		typeof json.html_url === "string"
+			? json.html_url
+			: `https://github.com/${GITHUB_REPO}/releases`;
+	return { version: tag.replace(/^v/, ""), name, body, htmlUrl };
+}
+
+/**
+ * Load GitHub release notes for `version` (tries tag `vX` then `X`, then latest).
+ */
+export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes> {
+	const base = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
+	const tagged =
+		(await fetchReleaseJson(`${base}/tags/${normalizeTag(version)}`)) ??
+		(await fetchReleaseJson(`${base}/tags/${version}`));
+	if (tagged) return parseRelease(tagged, version);
+
+	const latest = await fetchReleaseJson(`${base}/latest`);
+	if (latest) return parseRelease(latest, version);
+
+	return {
+		version,
+		name: `v${version}`,
+		body: `Mermaid Flow was updated to ${version}. Release notes could not be loaded right now.`,
+		htmlUrl: `https://github.com/${GITHUB_REPO}/releases`,
+	};
+}

--- a/src/feedback/version.ts
+++ b/src/feedback/version.ts
@@ -1,0 +1,9 @@
+/** Pure helper for tests — decide lifecycle action without touching Obsidian. */
+export function planVersionAction(
+	lastSeenVersion: string | null | undefined,
+	currentVersion: string,
+): "record" | "update" | "noop" {
+	if (!lastSeenVersion) return "record";
+	if (lastSeenVersion !== currentVersion) return "update";
+	return "noop";
+}

--- a/src/kofi.ts
+++ b/src/kofi.ts
@@ -1,0 +1,83 @@
+/** Ko-fi tip jar — used in settings and as the manifest fundingUrl. */
+export const KOFI_ID = "P0R02009G7";
+export const KOFI_URL = `https://ko-fi.com/${KOFI_ID}`;
+export const KOFI_WIDGET_SCRIPT =
+	"https://storage.ko-fi.com/cdn/widget/Widget_2.js";
+
+interface KofiWidget2 {
+	init: (text: string, color: string, id: string) => void;
+	draw: () => void;
+}
+
+/** Avoid calling draw() on every settings re-render (AI toggles, etc.). */
+let widgetDrawn = false;
+
+function getKofiApi(): KofiWidget2 | undefined {
+	return (activeWindow as Window & { kofiwidget2?: KofiWidget2 }).kofiwidget2;
+}
+
+function openKofi(): void {
+	activeWindow.open(KOFI_URL);
+}
+
+function mountFallbackLink(host: HTMLElement): void {
+	host.empty();
+	const btn = host.createEl("button", {
+		text: "Support me on Ko-fi",
+		cls: "mod-cta mermaid-flow-kofi-fallback",
+	});
+	btn.addEventListener("click", () => openKofi());
+}
+
+function drawInto(host: HTMLElement): void {
+	const api = getKofiApi();
+	if (!api || widgetDrawn) {
+		mountFallbackLink(host);
+		return;
+	}
+
+	api.init("Support me on Ko-fi", "#000000", KOFI_ID);
+
+	const body = activeDocument.body;
+	const before = new Set(Array.from(body.children));
+	api.draw();
+	widgetDrawn = true;
+
+	let moved = false;
+	for (const child of Array.from(body.children)) {
+		if (before.has(child)) continue;
+		host.appendChild(child);
+		moved = true;
+	}
+
+	if (!moved) mountFallbackLink(host);
+}
+
+/**
+ * Load Ko-fi Widget_2 into `parent` (settings). Falls back to a button that
+ * opens the Ko-fi page if the remote script fails (CSP / offline / mobile).
+ */
+export function mountKofiWidget(parent: HTMLElement): void {
+	const host = parent.createDiv({ cls: "mermaid-flow-kofi-widget" });
+
+	if (getKofiApi()) {
+		drawInto(host);
+		return;
+	}
+
+	const existing = activeDocument.querySelector<HTMLScriptElement>(
+		`script[src="${KOFI_WIDGET_SCRIPT}"]`,
+	);
+	if (existing) {
+		existing.addEventListener("load", () => drawInto(host));
+		if (getKofiApi()) drawInto(host);
+		return;
+	}
+
+	const script = activeDocument.createElement("script");
+	script.src = KOFI_WIDGET_SCRIPT;
+	script.async = true;
+	script.addEventListener("load", () => drawInto(host));
+	script.addEventListener("error", () => mountFallbackLink(host));
+	activeDocument.head.appendChild(script);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import {
 	isVisuallyEditable,
 } from "./diagramType";
 import { AltDiagramModal } from "./altDiagrams";
+import { runVersionLifecycle } from "./feedback";
 
 export default class MermaidFlowPlugin extends Plugin {
 	settings!: MermaidFlowSettings;
@@ -53,6 +54,7 @@ export default class MermaidFlowPlugin extends Plugin {
 	async onload(): Promise<void> {
 		await this.loadSettings();
 		this.addSettingTab(new MermaidFlowSettingTab(this.app, this));
+		runVersionLifecycle(this).catch((e) => console.error("[mermaid-flow]", e));
 
 		this.registerView(
 			VIEW_TYPE_MERMAID_FLOW,
@@ -111,6 +113,30 @@ export default class MermaidFlowPlugin extends Plugin {
 				if (!findMermaidBlockAtCursor(editor)) return false;
 				if (!checking) this.openAiFlow("improve", editor);
 				return true;
+			},
+		});
+
+		this.addCommand({
+			id: "open-feedback-form",
+			name: "Send feedback",
+			callback: () => {
+				window.open("https://geekstash.dev/mermaid-flow/feedback", "_blank");
+			},
+		});
+
+		this.addCommand({
+			id: "open-feature-request-form",
+			name: "Request a feature",
+			callback: () => {
+				window.open("https://geekstash.dev/mermaid-flow/feature-request", "_blank");
+			},
+		});
+
+		this.addCommand({
+			id: "open-uninstall-form",
+			name: "Send uninstall feedback",
+			callback: () => {
+				window.open("https://geekstash.dev/mermaid-flow/uninstall", "_blank");
 			},
 		});
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ import type { LibraryComponent } from "./componentLibrary";
 import type MermaidFlowPlugin from "./main";
 import { AiProviderId, AiSettings, CliPresetId, DEFAULT_AI_SETTINGS } from "./ai/types";
 import { CLI_PRESETS } from "./ai/cliProvider";
+import { mountKofiWidget } from "./kofi";
 
 export type OpenMode = "modal" | "pane";
 export type ToolbarStyle = "native" | "floating";
@@ -28,6 +29,8 @@ export interface MermaidFlowSettings {
 	ai: AiSettings;
 	/** User-saved reusable diagram snippets. */
 	componentLibrary: LibraryComponent[];
+	/** Last plugin version the user has seen (for update notices). */
+	lastSeenVersion: string | null;
 }
 
 export const DEFAULT_SETTINGS: MermaidFlowSettings = {
@@ -42,6 +45,7 @@ export const DEFAULT_SETTINGS: MermaidFlowSettings = {
 	snapSize: 10,
 	ai: DEFAULT_AI_SETTINGS,
 	componentLibrary: [],
+	lastSeenVersion: null,
 };
 
 export class MermaidFlowSettingTab extends PluginSettingTab {
@@ -290,6 +294,12 @@ export class MermaidFlowSettingTab extends PluginSettingTab {
 			});
 
 		this.displayAiSection(containerEl);
+
+		new Setting(containerEl).setName("Support").setHeading();
+		new Setting(containerEl)
+			.setName("Tip on Ko-fi")
+			.setDesc("If Mermaid Flow helps you, you can support development with a tip.");
+		mountKofiWidget(containerEl);
 
 		new Setting(containerEl).setName("Component library").setHeading();
 		const count = this.plugin.settings.componentLibrary?.length ?? 0;

--- a/styles.css
+++ b/styles.css
@@ -1332,3 +1332,107 @@
 @keyframes mermaid-flow-ai-spin {
 	to { transform: rotate(360deg); }
 }
+
+/* ===== Feedback / update modals ===== */
+
+.modal.mermaid-flow-feedback-modal {
+	width: min(480px, 92vw);
+}
+
+.modal.mermaid-flow-update-modal {
+	width: min(560px, 94vw);
+}
+
+.mermaid-flow-feedback-textarea {
+	width: 100%;
+	resize: vertical;
+	font-family: var(--font-interface);
+}
+
+.mermaid-flow-feedback-error {
+	color: var(--text-error);
+	font-size: var(--font-ui-small);
+	margin: 0 0 var(--size-4-2);
+}
+
+.mermaid-flow-feedback-footer {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: var(--size-4-2);
+	margin-top: var(--size-4-3);
+}
+
+.mermaid-flow-feedback-reasons {
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-2-3);
+	margin: var(--size-4-2) 0;
+}
+
+.mermaid-flow-feedback-reason {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--size-4-2);
+	padding: var(--size-4-2);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: var(--radius-s);
+	cursor: pointer;
+}
+
+.mermaid-flow-feedback-reason.is-on {
+	border-color: var(--interactive-accent);
+	background-color: var(--background-modifier-hover);
+}
+
+.mermaid-flow-feedback-reason strong {
+	display: block;
+	font-size: var(--font-ui-small);
+}
+
+.mermaid-flow-feedback-reason span {
+	display: block;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+}
+
+.mermaid-flow-feedback-loading {
+	color: var(--text-muted);
+	font-size: var(--font-ui-small);
+}
+
+.mermaid-flow-feedback-notes {
+	max-height: min(320px, 45vh);
+	overflow: auto;
+	margin: var(--size-4-2) 0;
+	padding: var(--size-4-2);
+	background-color: var(--background-secondary);
+	border-radius: var(--radius-s);
+}
+
+.mermaid-flow-feedback-notes-title {
+	margin: 0 0 var(--size-4-2);
+	font-size: var(--font-ui-medium);
+}
+
+.mermaid-flow-feedback-notes-body {
+	margin: 0 0 var(--size-4-2);
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-family: var(--font-interface);
+	font-size: var(--font-ui-small);
+	line-height: 1.45;
+}
+
+.mermaid-flow-feedback-notes-link {
+	font-size: var(--font-ui-small);
+}
+
+.mermaid-flow-kofi-widget {
+	margin: 0 0 var(--size-4-4);
+	padding: 0 var(--size-4-2);
+}
+
+.mermaid-flow-kofi-fallback {
+	margin-top: var(--size-2-2);
+}

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -8,6 +8,13 @@ vi.mock('obsidian', () => ({
 	PluginSettingTab: class {},
 	Setting: class {},
 	Platform: { isDesktopApp: true },
+	Modal: class {
+		app: unknown;
+		constructor(app: unknown) { this.app = app; }
+		open() {}
+		close() {}
+	},
+	Notice: class {},
 	requestUrl: (...args: unknown[]) => requestUrlMock(...args),
 }));
 

--- a/tests/feedback-api.test.ts
+++ b/tests/feedback-api.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("obsidian", () => ({
+	requestUrl: vi.fn(),
+}));
+
+import {
+	buildFeedbackBody,
+	buildFeatureRequestBody,
+	buildUninstallBody,
+	validateFeedback,
+	validateFeatureRequest,
+} from "../src/feedback/api";
+import { productUrl, PRODUCT_SLUG, API_BASE } from "../src/feedback/constants";
+
+describe("feedback API helpers", () => {
+	it("builds product URLs under the mermaid-flow slug", () => {
+		expect(PRODUCT_SLUG).toBe("mermaid-flow");
+		expect(productUrl("feedback")).toBe(
+			`${API_BASE}/products/mermaid-flow/feedback`,
+		);
+		expect(productUrl("feature-requests")).toBe(
+			`${API_BASE}/products/mermaid-flow/feature-requests`,
+		);
+		expect(productUrl("uninstall")).toBe(
+			`${API_BASE}/products/mermaid-flow/uninstall`,
+		);
+	});
+
+	it("builds feedback body with only provided fields", () => {
+		expect(
+			buildFeedbackBody({ topic: "settings", message: "  hello  ", rating: 4 }),
+		).toEqual({ topic: "settings", message: "hello", rating: 4 });
+		expect(buildFeedbackBody({ topic: "ui", rating: 5 })).toEqual({
+			topic: "ui",
+			rating: 5,
+		});
+	});
+
+	it("validates feedback requires message or rating", () => {
+		expect(validateFeedback({ topic: "settings" })).toMatch(/message|rating/i);
+		expect(validateFeedback({ topic: "settings", message: "ok" })).toBeNull();
+		expect(validateFeedback({ topic: "settings", rating: 3 })).toBeNull();
+		expect(validateFeedback({ topic: "settings", rating: 9 })).toMatch(/1 and 5/);
+	});
+
+	it("builds and validates feature requests", () => {
+		expect(
+			buildFeatureRequestBody({
+				email: " a@b.co ",
+				title: " Nested subgraphs ",
+				details: " Support deeper nesting. ",
+			}),
+		).toEqual({
+			email: "a@b.co",
+			title: "Nested subgraphs",
+			details: "Support deeper nesting.",
+		});
+		expect(
+			validateFeatureRequest({ email: "bad", title: "x", details: "y" }),
+		).toMatch(/email/i);
+		expect(
+			validateFeatureRequest({
+				email: "a@b.co",
+				title: "Title",
+				details: "Details here",
+			}),
+		).toBeNull();
+	});
+
+	it("builds uninstall body with optional reasons and message", () => {
+		expect(buildUninstallBody({})).toEqual({});
+		expect(
+			buildUninstallBody({
+				reasons: ["feature", "performance"],
+				message: " missing shapes ",
+			}),
+		).toEqual({
+			reasons: ["feature", "performance"],
+			message: "missing shapes",
+		});
+	});
+});

--- a/tests/feedback-lifecycle.test.ts
+++ b/tests/feedback-lifecycle.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { planVersionAction } from "../src/feedback/version";
+
+describe("planVersionAction", () => {
+	it("records version on first run", () => {
+		expect(planVersionAction(null, "1.5.0")).toBe("record");
+		expect(planVersionAction(undefined, "1.5.0")).toBe("record");
+		expect(planVersionAction("", "1.5.0")).toBe("record");
+	});
+
+	it("opens update when the version changed", () => {
+		expect(planVersionAction("1.4.4", "1.5.0")).toBe("update");
+	});
+
+	it("is a no-op when versions match", () => {
+		expect(planVersionAction("1.5.0", "1.5.0")).toBe("noop");
+	});
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -6,6 +6,15 @@ vi.mock('obsidian', () => ({
 	App: class {},
 	PluginSettingTab: class {},
 	Setting: class {},
+	Platform: { isDesktopApp: true },
+	Modal: class {
+		app: unknown;
+		constructor(app: unknown) { this.app = app; }
+		open() {}
+		close() {}
+	},
+	Notice: class {},
+	requestUrl: vi.fn(),
 }));
 
 import { DEFAULT_SETTINGS } from '../src/settings';
@@ -18,6 +27,7 @@ describe('DEFAULT_SETTINGS', () => {
 			defaultShape: 'rect',
 			savePositions: true,
 			autoSave: true,
+			lastSeenVersion: null,
 		});
 	});
 
@@ -40,6 +50,7 @@ describe('DEFAULT_SETTINGS', () => {
 		expect(merged.autoSave).toBe(false);
 		expect(merged.defaultDirection).toBe('LR');
 		expect(merged.openMode).toBe('modal'); // untouched default
+		expect(merged.lastSeenVersion).toBeNull();
 	});
 
 	it('deep-merges a partial saved ai block without masking new keys', () => {


### PR DESCRIPTION
Adds a new feedback subsystem with API/lifecycle helpers and tests, then wires user-facing feedback to command-palette web form links instead of in-plugin update/feedback prompts. Also introduces Ko-fi support in the manifest, settings, and README, and adds release-note governance docs (`CHANGELOG.md`, `release.md`, and agent guidance) to standardize future releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based forms for feedback, feature requests, and uninstall feedback.
  * Added release update notifications with version-specific notes and links.
  * Added a Support section with Ko-fi widget and fallback support button.
  * Added automatic detection of new versions.
* **Documentation**
  * Added release notes covering versions 1.0.0–1.5.0, upgrade guidance, and breaking changes.
  * Added guides and templates for preparing user-focused release notes.
* **Tests**
  * Added coverage for feedback submission, validation, settings, and version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->