### PR TITLE
fix: preserve YAML frontmatter instead of relocating it to the block end

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -223,6 +223,13 @@ export interface DiagramModel {
 	 * untouched so the visual editor never destroys advanced syntax.
 	 */
 	extras: string[];
+	/**
+	 * Mermaid v10.5+ YAML frontmatter (`---` … `---`), including both fences,
+	 * verbatim. It is only valid at the very top of a diagram, so it cannot go
+	 * through `extras` (which is re-emitted at the end); the serializer writes
+	 * it back first, before any other line.
+	 */
+	frontmatter?: string[];
 }
 
 export function emptyModel(direction: Direction = "TB"): DiagramModel {
@@ -462,5 +469,6 @@ export function cloneModel(model: DiagramModel): DiagramModel {
 				: undefined,
 		},
 		extras: [...model.extras],
+		frontmatter: model.frontmatter ? [...model.frontmatter] : undefined,
 	};
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -481,6 +481,27 @@ function splitLinkPieces(stmt: string): string[] {
 	return pieces;
 }
 
+/**
+ * Split leading YAML frontmatter (Mermaid v10.5+) off the source and store it,
+ * fences included, on `model.frontmatter`. Mermaid only accepts frontmatter as
+ * the first content of a diagram, so it cannot round-trip through `extras`
+ * (which is re-emitted at the end of the block). Recognized only when the
+ * opening `---` is closed, which keeps the `---` link operator (`A --- B`)
+ * out of it. Returns the lines left to parse.
+ */
+function takeFrontmatter(lines: string[], model: DiagramModel): string[] {
+	let start = 0;
+	while (start < lines.length && (lines[start] ?? "").trim() === "") start++;
+	if ((lines[start] ?? "").trim() !== "---") return lines;
+	for (let end = start + 1; end < lines.length; end++) {
+		if ((lines[end] ?? "").trim() !== "---") continue;
+		model.frontmatter = lines.slice(start, end + 1);
+		return lines.slice(end + 1);
+	}
+	// Never closed, so not frontmatter — leave every line to the parser.
+	return lines;
+}
+
 export function mermaidToModel(text: string): ParseResult {
 	const warnings: string[] = [];
 	const model = emptyModel("TB");
@@ -558,7 +579,10 @@ export function mermaidToModel(text: string): ParseResult {
 		groupStack.push(group);
 	};
 
-	const rawLines = text.replace(/\r\n/g, "\n").split("\n");
+	const rawLines = takeFrontmatter(
+		text.replace(/\r\n/g, "\n").split("\n"),
+		model,
+	);
 	let headerSeen = false;
 
 	for (const rawLine of rawLines) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -488,13 +488,20 @@ function splitLinkPieces(stmt: string): string[] {
  * (which is re-emitted at the end of the block). Recognized only when the
  * opening `---` is closed, which keeps the `---` link operator (`A --- B`)
  * out of it. Returns the lines left to parse.
+ *
+ * The closing fence has to carry the opening fence's indentation, mirroring the
+ * `\1` backreference in Mermaid's own `frontMatterRegex`: an indented `---`
+ * inside a multi-line YAML scalar would otherwise close the block early.
  */
 function takeFrontmatter(lines: string[], model: DiagramModel): string[] {
 	let start = 0;
 	while (start < lines.length && (lines[start] ?? "").trim() === "") start++;
-	if ((lines[start] ?? "").trim() !== "---") return lines;
+	// Mermaid allows the opening fence itself to be indented.
+	const open = (lines[start] ?? "").match(/^([^\S\n\r]*)---\s*$/);
+	if (!open) return lines;
+	const closeRe = new RegExp(`^${open[1] ?? ""}---\\s*$`);
 	for (let end = start + 1; end < lines.length; end++) {
-		if ((lines[end] ?? "").trim() !== "---") continue;
+		if (!closeRe.test(lines[end] ?? "")) continue;
 		model.frontmatter = lines.slice(start, end + 1);
 		return lines.slice(end + 1);
 	}

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -229,6 +229,11 @@ export function modelToMermaid(
 ): string {
 	const includePositions = opts.includePositions ?? true;
 	const lines: string[] = [];
+	// Frontmatter is only valid as the first content of the diagram, and is
+	// written back exactly as it was read (fences and YAML indentation included).
+	if (model.frontmatter && model.frontmatter.length > 0) {
+		lines.push(...model.frontmatter);
+	}
 	const directive = configDirective(model.config);
 	if (directive) lines.push(directive);
 	lines.push(`flowchart ${model.direction}`);

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -509,5 +509,48 @@ describe('mermaidToModel', () => {
 			const { model } = mermaidToModel(input);
 			expect(model.frontmatter).toBeUndefined();
 		});
+
+		it('does not let an indented --- inside a YAML block scalar close the fence', () => {
+			const input = [
+				'---',
+				'title: |',
+				'  first',
+				'  ---',
+				'  second',
+				'---',
+				'flowchart TD',
+				'  A --> B',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.frontmatter).toEqual([
+				'---',
+				'title: |',
+				'  first',
+				'  ---',
+				'  second',
+				'---',
+			]);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['A', 'B']);
+			expect(model.extras).toHaveLength(0);
+		});
+
+		it('accepts an indented fence pair', () => {
+			const input = [
+				'  ---',
+				'  title: Indented',
+				'  ---',
+				'flowchart TD',
+				'  A --> B',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.frontmatter).toEqual(['  ---', '  title: Indented', '  ---']);
+			expect(model.nodes).toHaveLength(2);
+		});
+
+		it('does not close an indented fence with a flush-left ---', () => {
+			const input = ['  ---', '  title: Indented', '---', 'flowchart TD'].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.frontmatter).toBeUndefined();
+		});
 	});
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -465,4 +465,49 @@ describe('mermaidToModel', () => {
 			expect(model.extras).toHaveLength(0);
 		});
 	});
+
+	describe('Issue #29: YAML frontmatter', () => {
+		it('captures frontmatter verbatim instead of leaking it into extras', () => {
+			const input = [
+				'---',
+				'title: My diagram',
+				'config:',
+				'  theme: dark',
+				'---',
+				'flowchart TD',
+				'  A[Start] --> B[End]',
+			].join('\n');
+			const { model, warnings } = mermaidToModel(input);
+			expect(model.frontmatter).toEqual([
+				'---',
+				'title: My diagram',
+				'config:',
+				'  theme: dark',
+				'---',
+			]);
+			expect(model.extras).toHaveLength(0);
+			expect(warnings).toHaveLength(0);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['A', 'B']);
+			expect(model.direction).toBe('TB');
+		});
+
+		it('leaves a --- link operator alone', () => {
+			const { model } = mermaidToModel('flowchart TD\n  A --- B');
+			expect(model.frontmatter).toBeUndefined();
+			expect(model.edges[0]?.kind).toBe('open');
+		});
+
+		it('does not treat an unclosed --- as frontmatter', () => {
+			const input = ['---', 'flowchart TD', '  A --> B'].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.frontmatter).toBeUndefined();
+			expect(model.nodes).toHaveLength(2);
+		});
+
+		it('ignores frontmatter that does not start the block', () => {
+			const input = ['flowchart TD', '  A --> B', '---', 'title: late', '---'].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.frontmatter).toBeUndefined();
+		});
+	});
 });

--- a/tests/serializer.test.ts
+++ b/tests/serializer.test.ts
@@ -466,4 +466,48 @@ describe('modelToMermaid', () => {
 			expect(back.nodes.find(n => n.id === 'EmptyGroup')).toBeUndefined();
 		});
 	});
+
+	describe('Issue #29: YAML frontmatter', () => {
+		const input = [
+			'---',
+			'title: My diagram',
+			'config:',
+			'  theme: dark',
+			'---',
+			'flowchart TD',
+			'  A[Start] --> B[End]',
+		].join('\n');
+
+		it('re-emits frontmatter at the top of the block, indentation intact', () => {
+			const out = modelToMermaid(mermaidToModel(input).model, {
+				includePositions: false,
+			});
+			expect(out.startsWith('---\ntitle: My diagram\nconfig:\n  theme: dark\n---\n')).toBe(true);
+			expect(out.split('\n')[5]).toBe('flowchart TB');
+		});
+
+		it('keeps the frontmatter above the position comment on a full save', () => {
+			const model = mermaidToModel(input).model;
+			const out = modelToMermaid(model, { includePositions: true });
+			expect(out.indexOf('---')).toBeLessThan(out.indexOf('flowchart'));
+			expect(out).toContain('%% mermaid-flow:pos');
+		});
+
+		it('is stable across a second round trip', () => {
+			const once = modelToMermaid(mermaidToModel(input).model, {
+				includePositions: false,
+			});
+			const twice = modelToMermaid(mermaidToModel(once).model, {
+				includePositions: false,
+			});
+			expect(twice).toBe(once);
+		});
+
+		it('emits nothing extra when there is no frontmatter', () => {
+			const out = modelToMermaid(mermaidToModel('flowchart TD\n  A --> B').model, {
+				includePositions: false,
+			});
+			expect(out.startsWith('flowchart TB')).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #29.

## Problem

`detectDiagramType` skips Mermaid v10.5+ YAML frontmatter and reports the block as a `flowchart`, so a block with frontmatter is routed into the visual editor — but `parser.ts` has no branch for it. The `---` fences and the YAML body fall through to `model.extras`, and the serializer re-emits `extras` at the **end** of the block. Frontmatter is only valid at the top, so the saved diagram stops rendering; the re-emitted lines also lose their indentation, which flattens nested YAML such as `config:` / `theme:`.

Before:

```
---
title: My diagram
config:
  theme: dark
---
flowchart TD
  A[Start] --> B[End]
```

became

```
flowchart TB
    A["Start"]
    B["End"]
    A --> B
    ---
    title: My diagram
    config:
    theme: dark
    ---
```

After this change the same input round-trips to:

```
---
title: My diagram
config:
  theme: dark
---
flowchart TB
    A["Start"]
    B["End"]
    A --> B
    %% mermaid-flow:pos A=… B=…
```

## Approach

- `model.ts` — new optional `frontmatter?: string[]` on `DiagramModel`, holding the block verbatim (both fences included). Optional so existing model literals (`templates.ts`, tests) are untouched. `cloneModel` copies it.
- `parser.ts` — `takeFrontmatter()` splits it off before the line loop. It only triggers on the first content of the block, and only when the opening `---` is closed, so the `---` link operator (`A --- B`) and an unclosed `---` are left to the normal parser.
- `serializer.ts` — emitted first, ahead of the init directive and the header, verbatim (no re-indenting).

Frontmatter is kept opaque on purpose: no attempt to merge `config:` into `model.config`, which would collide with the existing `%%{init}%%` handling and give two sources for the same settings. It is preserved, not edited — which matches how `extras` is treated, just with the correct position.

## Tests

7 new cases (4 parser, 3 serializer + 1 no-frontmatter regression), written before the fix and failing without it:

- frontmatter captured verbatim, `extras` stays empty, no warnings, nodes still parse
- `A --- B` link operator not mistaken for a fence
- unclosed `---` not treated as frontmatter
- `---` appearing after diagram content not treated as frontmatter
- re-emitted at the top with indentation intact, above the `%% mermaid-flow:pos` comment
- stable across a second round trip
- output with no frontmatter still starts at `flowchart`

`npm test` 250 passed · `npm run lint` 0 errors · `npm run build` clean · `npm run validate` clean.

No version or CHANGELOG bump — left to the maintainer's release flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for YAML frontmatter in Mermaid diagrams.
  * Preserved frontmatter during parsing, editing, saving, and round trips.
  * Emitted frontmatter at the beginning of generated diagrams, including preserved indentation.

* **Bug Fixes**
  * Prevented valid frontmatter from being interpreted as diagram content.
  * Improved handling of indented fences and YAML block scalars.
  * Unmatched or incorrectly indented delimiters remain diagram content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->