### PR TITLE
fix: do not mint a ghost node for edges targeting a subgraph

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -496,6 +496,10 @@ export function mermaidToModel(text: string): ParseResult {
 	const styleDirectives: Array<{ id: string; props: string }> = [];
 	const classAssignments: Array<{ ids: string[]; className: string }> = [];
 	const clickBindings: Array<{ id: string; target: string; raw: string }> = [];
+	// Ids only ever seen as a bare reference (`B --> S`, `style S ...`) — never
+	// declared with a shape or label. A subgraph id reaching us this way is not
+	// a node at all; see the ghost sweep after parsing.
+	const implicitNodeIds = new Set<string>();
 
 	const ensureNode = (token: ParsedToken): DiagramNode => {
 		let node = nodeMap.get(token.id);
@@ -509,11 +513,17 @@ export function mermaidToModel(text: string): ParseResult {
 			};
 			nodeMap.set(token.id, node);
 			model.nodes.push(node);
+			if (token.shape === undefined && token.label === undefined) {
+				implicitNodeIds.add(token.id);
+			}
 		} else {
 			// A later, richer declaration wins (e.g. shape/label defined inline
 			// in an edge statement after a bare reference).
 			if (token.shape) node.shape = token.shape;
 			if (token.label !== undefined) node.label = token.label;
+			if (token.shape !== undefined || token.label !== undefined) {
+				implicitNodeIds.delete(token.id);
+			}
 		}
 		for (const c of token.classes ?? []) {
 			if (!node.classes?.includes(c)) (node.classes ??= []).push(c);
@@ -769,6 +779,28 @@ export function mermaidToModel(text: string): ParseResult {
 			}
 		}
 		edge.style = { ...edge.style, ...parsed };
+	}
+
+	// A subgraph id may legally stand where a node id is expected (`B --> S`,
+	// `style S ...`). Any node minted for such an id is a ghost — drop it so the
+	// serializer does not emit a stray `S["S"]` beside the subgraph. Only
+	// implicitly created ids qualify; an explicit `S[Label]` declaration is left
+	// alone. Groups that hold no content are skipped: they are discarded below,
+	// so their id has to stay a node or the edge would lose its endpoint.
+	const liveGroupIds = new Set(
+		model.groups.filter((g) => groupSubtreeHasNodes(model, g.id)).map((g) => g.id),
+	);
+	const ghostIds = new Set(
+		[...implicitNodeIds].filter((id) => liveGroupIds.has(id)),
+	);
+	if (ghostIds.size > 0) {
+		model.nodes = model.nodes.filter((n) => !ghostIds.has(n.id));
+		for (const group of model.groups) {
+			group.nodeIds = group.nodeIds.filter((id) => !ghostIds.has(id));
+		}
+		// Keep nodeMap in step so a `click <subgraphId>` binding below falls
+		// through to extras instead of attaching to a node we just dropped.
+		for (const id of ghostIds) nodeMap.delete(id);
 	}
 
 	// Drop groups with no nodes in their entire subtree (keeps outer shells

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -465,4 +465,102 @@ describe('mermaidToModel', () => {
 			expect(model.extras).toHaveLength(0);
 		});
 	});
+
+	describe('Issue #30: edges targeting a subgraph', () => {
+		it('does not mint a ghost node when an edge points at a subgraph', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1',
+				'    A',
+				'  end',
+				'  B --> Group1',
+			].join('\n');
+			const { model, warnings } = mermaidToModel(input);
+			expect(warnings).toHaveLength(0);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['A', 'B']);
+			expect(model.nodes.find(n => n.id === 'Group1')).toBeUndefined();
+			expect(model.edges).toHaveLength(1);
+			expect(model.edges[0]?.to).toBe('Group1');
+		});
+
+		it('does not mint a ghost node when the edge precedes the subgraph', () => {
+			const input = [
+				'flowchart TB',
+				'  B --> Group1',
+				'  subgraph Group1',
+				'    A',
+				'  end',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['A', 'B']);
+			expect(model.edges[0]?.to).toBe('Group1');
+		});
+
+		it('handles a subgraph as the edge source', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1',
+				'    A',
+				'  end',
+				'  Group1 --> B',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['A', 'B']);
+			expect(model.edges[0]?.from).toBe('Group1');
+		});
+
+		it('does not add the subgraph id to an enclosing group members list', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Inner',
+				'    A',
+				'  end',
+				'  subgraph Outer',
+				'    B --> Inner',
+				'  end',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			const outer = model.groups.find(g => g.id === 'Outer');
+			expect(outer?.nodeIds).toEqual(['B']);
+		});
+
+		it('leaves an explicitly declared node alone', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1',
+				'    A',
+				'  end',
+				'  Group2[Real node] --> Group1',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.nodes.find(n => n.id === 'Group2')?.label).toBe('Real node');
+		});
+
+		it('keeps the node when the subgraph is empty and therefore dropped', () => {
+			// The empty subgraph is discarded, so its id has to stay a node or
+			// the edge would lose its endpoint.
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1',
+				'  end',
+				'  B --> Group1',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.groups).toHaveLength(0);
+			expect(model.nodes.map(n => n.id).sort()).toEqual(['B', 'Group1']);
+		});
+
+		it('keeps a click binding on a subgraph id instead of dropping it', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1',
+				'    A',
+				'  end',
+				'  click Group1 "https://example.com"',
+			].join('\n');
+			const { model } = mermaidToModel(input);
+			expect(model.nodes.find(n => n.id === 'Group1')).toBeUndefined();
+			expect(model.extras).toContain('click Group1 "https://example.com"');
+		});
+	});
 });

--- a/tests/serializer.test.ts
+++ b/tests/serializer.test.ts
@@ -466,4 +466,39 @@ describe('modelToMermaid', () => {
 			expect(back.nodes.find(n => n.id === 'EmptyGroup')).toBeUndefined();
 		});
 	});
+
+	describe('Issue #30: edges targeting a subgraph', () => {
+		it('round-trips an edge into a subgraph without emitting a ghost node', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1[Grp]',
+				'    A',
+				'  end',
+				'  B --> Group1',
+			].join('\n');
+			const out = modelToMermaid(mermaidToModel(input).model, {
+				includePositions: false,
+			});
+			expect(lines(out)).toContain('B --> Group1');
+			expect(out).not.toContain('Group1["Group1"]');
+			expect(out).not.toContain('Group1[Group1]');
+		});
+
+		it('is stable across a second round trip', () => {
+			const input = [
+				'flowchart TB',
+				'  subgraph Group1[Grp]',
+				'    A',
+				'  end',
+				'  B --> Group1',
+			].join('\n');
+			const once = modelToMermaid(mermaidToModel(input).model, {
+				includePositions: false,
+			});
+			const twice = modelToMermaid(mermaidToModel(once).model, {
+				includePositions: false,
+			});
+			expect(twice).toBe(once);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #30.

## Problem

An edge may legally target a subgraph (`B --> Group1`), but `ensureNode` has no knowledge of `model.groups`, so a node with the subgraph's id is minted and the serializer emits it alongside the subgraph:

```
flowchart TB
  subgraph Group1[Grp]
    A
  end
  B --> Group1
```

round-tripped to

```
flowchart TB
    subgraph Group1 ["Grp"]
        A["A"]
    end
    B["B"]
    Group1["Group1"]        <-- ghost
    B --> Group1
```

Same ghost-node class as #27 (`style <subgraphId>`), which was fixed by checking `model.groups` before falling back to `ensureNode`. The edge path never got that guard.

## Approach

A guard at the `ensureNode` call site would not be enough: the forward reference

```
B --> Group1
subgraph Group1
  A
end
```

parses the edge before the group exists. So the fix records ids that were only ever seen as a **bare** reference (no shape, no label) and sweeps them once parsing is done:

- a node whose id names a live subgraph is dropped from `model.nodes` and from any group's `nodeIds` (first mention inside a subgraph would otherwise enroll the ghost as a member)
- `nodeMap` is kept in step so a `click <subgraphId>` binding falls through to `extras` instead of attaching to a dropped node
- explicitly declared nodes (`Group1[Label]`) are never swept
- groups with no content are excluded: they are discarded right below the sweep, so their id has to stay a node or the edge would lose its endpoint

The edge itself stays in `model.edges`, so it serializes unchanged and `linkStyle` indices keep lining up. `canvas.ts` already skips edges whose endpoint is not a node (`if (!from || !to) continue`), so nothing renders differently — the edge is simply not drawn, as before, but the stray rectangle is gone.

This is deliberately the minimal fix. Anchoring such an edge to the subgraph's box on the canvas would be the fuller answer; happy to follow up if you want that.

## Tests

9 new cases (7 parser, 2 serializer), written before the fix — 4 of them fail without it:

- edge into a subgraph: no ghost, edge kept with `to === 'Group1'`
- forward reference (edge before the subgraph)
- subgraph as the edge source
- ghost not added to an enclosing group's `nodeIds`
- explicitly declared node left alone
- empty subgraph is dropped, so its id correctly stays a node
- `click <subgraphId>` preserved in `extras`
- round-trip emits `B --> Group1` with no `Group1["Group1"]`, and is stable on a second pass

`npm test` 251 passed · `npm run lint` 0 errors · `npm run build` clean · `npm run validate` clean.

No version or CHANGELOG bump — left to the maintainer's release flow.
